### PR TITLE
Fix an asciidoc syntax and a typo

### DIFF
--- a/workshop/content/ocp4ws-ops-1-1.adoc
+++ b/workshop/content/ocp4ws-ops-1-1.adoc
@@ -371,6 +371,7 @@ openshift-vsphere-infra                                                Active
 CAUTION: 作成したProjectの名前が"lab1-1"でない場合は、各自のProject名に置き替えてください。
 ====
 +
+
 +
 [source,bash,role="copypaste"]
 ----

--- a/workshop/content/ocs4-3.adoc
+++ b/workshop/content/ocs4-3.adoc
@@ -189,7 +189,7 @@ password: secret
 
 作成された記事とコメントはPostgreSQLデータベースに保存されます。PostgreSQLデータベースは、アプリケーションのデプロイ中に `ocs-storagecluster-ceph-rbd` *StorageClass* を使ってプロビジョニングされたCeph RBDボリュームにテーブルスペースを保存します。 +
 そのため、PostgreSQLのPodを削除してもデータが失われることはありません。試しにPostgreSQLのPodを削除してみましょう。 +
-PostgreSQLのPodはDeploymentConfigによって削除されても自動的に再作成され、すでに存在するPVを自動でマウントするるようになっています。
+PostgreSQLのPodはDeploymentConfigによって削除されても自動的に再作成され、すでに存在するPVを自動でマウントするようになっています。
 
 [source,role="execute"]
 ----


### PR DESCRIPTION
1. Since the code "+\n+" did not work, updated it to "+\n\n+".
2. Fix a typo.